### PR TITLE
다음 주소 api 연동 및 선택 정보 콤보박스 토글기능 추가

### DIFF
--- a/bamin-13/public/scripts/modal.js
+++ b/bamin-13/public/scripts/modal.js
@@ -11,6 +11,8 @@ const openModal=()=>{
 const closeModal=()=>{
     // console.log('close');
     modal.classList.add('hidden');
+    
+
 }
 
 authBtn.addEventListener('click',openModal);

--- a/bamin-13/public/scripts/signup.js
+++ b/bamin-13/public/scripts/signup.js
@@ -2,6 +2,34 @@
 const formElement = document.querySelector('form');
 const checkList = ['id', 'password', 'name','password-chk'];
 
+const postalBox = new daum.Postcode({
+    oncomplete: function(data) {
+        const {zonecode, address} = data;
+        document.getElementById('postcode').value = zonecode;
+        document.getElementById('address').value = address;
+    }
+})
+
+const openPostalButton = document.querySelector('#address-btn')
+openPostalButton.addEventListener('click', ()=>{
+    postalBox.open();
+})
+
+const addressCheckBox = document.getElementById('select-info-chk')
+function setAddressBoxEnabled(value){
+    const addressBox = document.getElementById('postcode-box')
+    addressBox.childNodes.forEach(node=>{
+        node.childNodes.forEach(elem=>{
+            elem.disabled = !value
+        })
+    })
+}
+setAddressBoxEnabled(false);
+addressCheckBox.addEventListener('input', (event)=>{
+    const {checked} = event.target
+    setAddressBoxEnabled(checked);
+})
+
 // 이벤트 위임 
 // 텍스트 입력창에서 벗어날 때 유효성 검사 조건에 맞지 않으면 경고문 보여준다
 formElement.addEventListener('focusout', (event)=>{

--- a/bamin-13/public/scripts/utils.js
+++ b/bamin-13/public/scripts/utils.js
@@ -20,6 +20,7 @@ function validatePasswordChk(password,passwordChk){
 
 
 
+
 /*
 console.log(validateId('1231dDSFSDF'))
 console.log(validateId('1231-123'))

--- a/bamin-13/public/stylesheets/signup.css
+++ b/bamin-13/public/stylesheets/signup.css
@@ -52,6 +52,8 @@ box-sizing: border-box;
     padding:7px;
 }
 
+
+
 .email-flex-container{
     display:flex;
     height:47px;
@@ -111,6 +113,13 @@ box-sizing: border-box;
 #email-select{
     margin-top:20px;
 }
+
+.postcode{
+    width:400px;
+    display:flex;
+    flex-direction:column;
+}
+
 .address-flex-chk-container{
     width:400px;
     display:flex;
@@ -139,13 +148,16 @@ box-sizing: border-box;
 
 .postcode-flex-container, .address-flex-container{
     display:flex;
-    height:47px;
+    min-height:47px;
     width:400px;
     justify-content: space-between;
+    margin: 0.5em 0em;
 }
 
+
 .address-flex-item{
-    margin:0.5em 2em;
+    /* margin:0.5em 2em; */
+    margin: 0.5em 0em;
 }
 
 #signup-finish-btn{

--- a/bamin-13/views/signup.pug
+++ b/bamin-13/views/signup.pug
@@ -4,9 +4,10 @@ head
   meta(name='viewport' content='width=device-width, initial-scale=1.0')
   link(rel='stylesheet' href='/stylesheets/signup.css')
   link(rel='stylesheet' href='/stylesheets/modal.css')
-  script(src='/scripts/utils.js' defer='')
-  script(src='/scripts/signup.js' defer='')
-  script(src='/scripts/modal.js' defer='')
+  script(src='/scripts/utils.js' defer)
+  script(src='/scripts/signup.js' defer)
+  script(src='/scripts/modal.js' defer)
+  script(src='https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js')
   title Signup page
 .wrapper
   .signup-container
@@ -39,7 +40,7 @@ head
         input#auth-btn.auth-flex-item(value='인증받기')
 
       div(style='margin:0.5em auto')
-      #auth.auth-container
+      #auth.auth-container.hidden
         input#auth-number-input.auth-flex-item(name="authNumber" type='text' placeholder='인증번호 6자리 입력')
         input#number-submit-btn.auth-flex-item(value='확인')
       #number-alert.alert-message 인증번호를 입력해주세요.
@@ -48,12 +49,14 @@ head
         input#select-info-chk(type='checkbox')
         p 선택 정보를 입력하시겠어요?
         ul 내용보기
-      .postcode-flex-container
-        input#postcode.postcode-flex-item(name="postalCode" type='text' placeholder='우편번호')
-        input#address-btn.postcode-flex-item(type='submit' value='주소찾기')
-      div(style='margin-bottom:0.5em')
-      input#address.address-flex-item(name="address" type='text' placeholder='주소')
-      input#detail-address.address-flex-item(name="detailAddress" type='text' placeholder='상세주소')
+      #postcode-box.postcode
+        .postcode-flex-container(style="margin:0")
+          input#postcode.postcode-flex-item(name="postalCode" type='text' placeholder='우편번호')
+          input#address-btn.postcode-flex-item(value='주소찾기')
+        div(style='margin-bottom:0.5em')
+        .postcode-flex-container(style="margin:0;flex-direction:column")
+          input#address.address-flex-item(name="address" type='text' placeholder='주소')
+          input#detail-address.address-flex-item(name="detailAddress" type='text' placeholder='상세주소')
       .terms-flex-container
         input#terms-agree-chk(type='checkbox')
         p 전체 약관에 동의합니다.


### PR DESCRIPTION
- 다음 카카오 맵 api 연동 
 [주소 api http://postcode.map.daum.net/guide](http://postcode.map.daum.net/guide)

- 주소 선택 정보 입력 콤보박스 체크로 주소 입력기능 활성화
- 콤보박스 토글 기능 추가

closes #31 
closes #17